### PR TITLE
Rorf story1582

### DIFF
--- a/src/main/java/jobmanager/messaging/handler/RepeatJobHandler.java
+++ b/src/main/java/jobmanager/messaging/handler/RepeatJobHandler.java
@@ -77,7 +77,7 @@ public class RepeatJobHandler {
 			// who requested the Job to be repeated. The Job Type will be the
 			// Type of the Job that is to be repeated.
 			PiazzaJobRequest request = new PiazzaJobRequest();
-			request.apiKey = repeatJob.submitterApiKey;
+			request.userName = repeatJob.submitterUserName;
 			request.jobType = job.getJobType();
 
 			// Dispatch the Message to Repeat the selected Job. Create an ID so

--- a/src/test/java/jobmanager/test/JobControllerTests.java
+++ b/src/test/java/jobmanager/test/JobControllerTests.java
@@ -24,6 +24,7 @@ import jobmanager.controller.JobController;
 import jobmanager.database.MongoAccessor;
 import model.job.Job;
 import model.job.JobProgress;
+import model.job.type.IngestJob;
 import model.response.ErrorResponse;
 import model.response.JobStatusResponse;
 import model.response.PiazzaResponse;
@@ -74,6 +75,7 @@ public class JobControllerTests {
 		mockJob.jobId = UUID.randomUUID().toString();
 		mockJob.status = StatusUpdate.STATUS_RUNNING;
 		mockJob.progress = new JobProgress(75);
+		mockJob.jobType = new IngestJob();
 
 		// When we query the Status of the Mock Job's ID, return the Mock Job
 		when(accessor.getJobById(mockJob.jobId)).thenReturn(mockJob);
@@ -85,5 +87,6 @@ public class JobControllerTests {
 		assertTrue(jobStatus.jobId.equals(mockJob.getJobId()));
 		assertTrue(jobStatus.progress.equals(mockJob.progress));
 		assertTrue(jobStatus.status.equals(StatusUpdate.STATUS_RUNNING));
+		assertTrue(jobStatus.jobType.equals(mockJob.getJobType().getType()));
 	}
 }


### PR DESCRIPTION
- Updated AbortJobHandler to accept the entire PiazzaJobRequest object, check the requesting user against the Job owner, reject if they do not match.
- Updated RepeatJobHandler to reflect the PiazzaJobRequest field name change from 'apiKey' to 'userName'.
